### PR TITLE
feat: release v3.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "action.yml"
   ],
   "dependencies": {
-    "@actions/core": "^1.2.2",
+    "@actions/core": "^1.2.3",
     "@actions/github": "^2.1.1",
     "@technote-space/filter-github-action": "^0.2.5",
     "@technote-space/github-action-helper": "^1.2.2",
@@ -39,8 +39,8 @@
     "@technote-space/release-github-actions-cli": "^1.3.0",
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.7",
-    "@typescript-eslint/eslint-plugin": "^2.21.0",
-    "@typescript-eslint/parser": "^2.21.0",
+    "@typescript-eslint/eslint-plugin": "^2.22.0",
+    "@typescript-eslint/parser": "^2.22.0",
     "eslint": "^6.8.0",
     "husky": "^4.2.3",
     "jest": "^25.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/release-github-actions",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "GitHub actions to auto release.",
   "author": {
     "name": "Technote",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.2.tgz#3c4848d50378f9e3bcb67bcf97813382ec7369ee"
-  integrity sha512-IbCx7oefq+Gi6FWbSs2Fnw8VkEI6Y4gvjrYprY3RV//ksq/KPMlClOerJ4jRosyal6zkUIc8R9fS/cpRMlGClg==
+"@actions/core@^1.2.2", "@actions/core@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.3.tgz#e844b4fa0820e206075445079130868f95bfca95"
+  integrity sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w==
 
 "@actions/github@^2.1.1":
   version "2.1.1"
@@ -603,7 +603,7 @@
   dependencies:
     type-detect "4.0.8"
 
-"@technote-space/filter-github-action@^0.2.4", "@technote-space/filter-github-action@^0.2.5":
+"@technote-space/filter-github-action@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@technote-space/filter-github-action/-/filter-github-action-0.2.5.tgz#53aea7cf9026bb86cb89ad2053197d07336e9c86"
   integrity sha512-+hKxXMVdmkB0tTVZLvUwwLLHYiweD8DJZUuPjjrmXJgu6HC6j349gywYCSBmBjoFAlGip+vhbpKnWBNDV2ht+g==
@@ -611,7 +611,7 @@
     "@actions/core" "^1.2.2"
     "@actions/github" "^2.1.1"
 
-"@technote-space/github-action-helper@^1.2.0", "@technote-space/github-action-helper@^1.2.2":
+"@technote-space/github-action-helper@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@technote-space/github-action-helper/-/github-action-helper-1.2.2.tgz#59b7df8e33b76b85318b5ed31b43f60ccb92493f"
   integrity sha512-19qwKzHKbfRGy8avyYi3x/ekvLoWvE3Qv2bUf6kQDQDPS2/WRW2p9lCUtSjEecZ3Sa65t/cTcgjYuMUWwOtc8g==
@@ -641,14 +641,14 @@
     js-yaml "^3.13.1"
 
 "@technote-space/release-github-actions@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@technote-space/release-github-actions/-/release-github-actions-3.0.4.tgz#b1eb24a3b0c7235a1f088b507d999931f02b069e"
-  integrity sha512-QFuExp6x3g/IWNpbGbnGDBmayB0qULzR5Iekmuk7gzqetgVzQohYhdo29GqEUIOLRL7Kma3kskl5Bw+4SfqQmw==
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@technote-space/release-github-actions/-/release-github-actions-3.0.5.tgz#1af9ddccbbfe7f56d186736982d8dbff44ced703"
+  integrity sha512-XVM+v1GAcKDsAsRQ4lT7THr85eZEegA2UVuv6GHR2KtbgYpPIW4WchrMEzy6NbQ5dHw6lsxZTcTuU4pqSBTrFQ==
   dependencies:
     "@actions/core" "^1.2.2"
     "@actions/github" "^2.1.1"
-    "@technote-space/filter-github-action" "^0.2.4"
-    "@technote-space/github-action-helper" "^1.2.0"
+    "@technote-space/filter-github-action" "^0.2.5"
+    "@technote-space/github-action-helper" "^1.2.2"
     moment "^2.24.0"
 
 "@types/babel__core@^7.1.0":
@@ -754,40 +754,40 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.21.0.tgz#a34de84a0791cae0357c4dda805c5b4e8203b6c6"
-  integrity sha512-b5jjjDMxzcjh/Sbjuo7WyhrQmVJg0WipTHQgXh5Xwx10uYm6nPWqN1WGOsaNq4HR3Zh4wUx4IRQdDkCHwyewyw==
+"@typescript-eslint/eslint-plugin@^2.22.0":
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.22.0.tgz#218ce6d4aa0244c6a40baba39ca1e021b26bb017"
+  integrity sha512-BvxRLaTDVQ3N+Qq8BivLiE9akQLAOUfxNHIEhedOcg8B2+jY8Rc4/D+iVprvuMX1AdezFYautuGDwr9QxqSxBQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.21.0"
+    "@typescript-eslint/experimental-utils" "2.22.0"
     eslint-utils "^1.4.3"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.21.0.tgz#71de390a3ec00b280b69138d80733406e6e86bfa"
-  integrity sha512-olKw9JP/XUkav4lq0I7S1mhGgONJF9rHNhKFn9wJlpfRVjNo3PPjSvybxEldvCXnvD+WAshSzqH5cEjPp9CsBA==
+"@typescript-eslint/experimental-utils@2.22.0":
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.22.0.tgz#4d00c91fbaaa68e56e7869be284999a265707f85"
+  integrity sha512-sJt1GYBe6yC0dWOQzXlp+tiuGglNhJC9eXZeC8GBVH98Zv9jtatccuhz0OF5kC/DwChqsNfghHx7OlIDQjNYAQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.21.0"
+    "@typescript-eslint/typescript-estree" "2.22.0"
     eslint-scope "^5.0.0"
 
-"@typescript-eslint/parser@^2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.21.0.tgz#4f200995517c3d5fc5ef51b17527bc948992e438"
-  integrity sha512-VrmbdrrrvvI6cPPOG7uOgGUFXNYTiSbnRq8ZMyuGa4+qmXJXVLEEz78hKuqupvkpwJQNk1Ucz1TenrRP90gmBg==
+"@typescript-eslint/parser@^2.22.0":
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.22.0.tgz#8eeb6cb6de873f655e64153397d4790898e149d0"
+  integrity sha512-FaZKC1X+nvD7qMPqKFUYHz3H0TAioSVFGvG29f796Nc5tBluoqfHgLbSFKsh7mKjRoeTm8J9WX2Wo9EyZWjG7w==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.21.0"
-    "@typescript-eslint/typescript-estree" "2.21.0"
+    "@typescript-eslint/experimental-utils" "2.22.0"
+    "@typescript-eslint/typescript-estree" "2.22.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.21.0.tgz#7e4be29f2e338195a2e8c818949ed0ff727cc943"
-  integrity sha512-NC/nogZNb9IK2MEFQqyDBAciOT8Lp8O3KgAfvHx2Skx6WBo+KmDqlU3R9KxHONaijfTIKtojRe3SZQyMjr3wBw==
+"@typescript-eslint/typescript-estree@2.22.0":
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.22.0.tgz#a16ed45876abf743e1f5857e2f4a1c3199fd219e"
+  integrity sha512-2HFZW2FQc4MhIBB8WhDm9lVFaBDy6h9jGrJ4V2Uzxe/ON29HCHBTj3GkgcsgMWfsl2U5as+pTOr30Nibaw7qRQ==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -818,7 +818,7 @@ acorn-globals@^4.3.2:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
-acorn-jsx@^5.1.0:
+acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
   integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
@@ -1811,12 +1811,12 @@ eslint@^6.8.0:
     v8-compile-cache "^2.0.3"
 
 espree@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.2.tgz#6c272650932b4f91c3714e5e7b5f5e2ecf47262d"
-  integrity sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.0.tgz#349fef01a202bbab047748300deb37fa44da79d7"
+  integrity sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==
   dependencies:
     acorn "^7.1.0"
-    acorn-jsx "^5.1.0"
+    acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
 esprima@^4.0.0, esprima@^4.0.1:


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (180efb24fd984fd18eeb120ec7caee4e26ea1740)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/release-github-actions/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v1/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>ncu -u --packageFile package.json</em></summary>

```Shell
Upgrading /home/runner/work/release-github-actions/release-github-actions/package.json

 @actions/core                      ^1.2.2  →   ^1.2.3 
 @typescript-eslint/eslint-plugin  ^2.21.0  →  ^2.22.0 
 @typescript-eslint/parser         ^2.21.0  →  ^2.22.0 

Run npm install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.21.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.2: The platform "linux" is incompatible with this module.
info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 20.42s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.21.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.2: The platform "linux" is incompatible with this module.
info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 449 new dependencies.
info Direct dependencies
├─ @commitlint/cli@8.3.5
├─ @commitlint/config-conventional@8.3.4
├─ @technote-space/github-action-test-helper@0.2.5
├─ @technote-space/release-github-actions-cli@1.3.0
├─ @types/jest@25.1.3
├─ @types/node@13.7.7
├─ @typescript-eslint/eslint-plugin@2.22.0
├─ @typescript-eslint/parser@2.22.0
├─ eslint@6.8.0
├─ husky@4.2.3
├─ jest-circus@25.1.0
├─ jest@25.1.0
├─ lint-staged@10.0.8
├─ nock@12.0.2
├─ ts-jest@25.2.1
└─ typescript@3.8.3
info All dependencies
├─ @actions/http-client@1.0.6
├─ @babel/core@7.8.6
├─ @babel/helper-function-name@7.8.3
├─ @babel/helper-get-function-arity@7.8.3
├─ @babel/helper-split-export-declaration@7.8.3
├─ @babel/helpers@7.8.4
├─ @babel/highlight@7.8.3
├─ @babel/plugin-syntax-bigint@7.8.3
├─ @babel/plugin-syntax-object-rest-spread@7.8.3
├─ @babel/runtime@7.8.4
├─ @bcoe/v8-coverage@0.2.3
├─ @cnakazawa/watch@1.0.4
├─ @commitlint/cli@8.3.5
├─ @commitlint/config-conventional@8.3.4
├─ @commitlint/ensure@8.3.4
├─ @commitlint/execute-rule@8.3.4
├─ @commitlint/format@8.3.4
├─ @commitlint/is-ignored@8.3.5
├─ @commitlint/lint@8.3.5
├─ @commitlint/load@8.3.5
├─ @commitlint/message@8.3.4
├─ @commitlint/parse@8.3.4
├─ @commitlint/read@8.3.4
├─ @commitlint/resolve-extends@8.3.5
├─ @commitlint/rules@8.3.4
├─ @commitlint/to-lines@8.3.4
├─ @commitlint/top-level@8.3.4
├─ @istanbuljs/load-nyc-config@1.0.0
├─ @jest/reporters@25.1.0
├─ @jest/test-sequencer@25.1.0
├─ @marionebl/sander@0.6.1
├─ @octokit/auth-token@2.4.0
├─ @octokit/endpoint@5.5.3
├─ @octokit/graphql@4.3.1
├─ @octokit/plugin-paginate-rest@1.1.2
├─ @octokit/plugin-request-log@1.0.0
├─ @octokit/plugin-rest-endpoint-methods@2.4.0
├─ @octokit/request-error@1.2.1
├─ @octokit/request@5.3.2
├─ @octokit/rest@16.43.1
├─ @samverschueren/stream-to-observable@0.3.0
├─ @sinonjs/commons@1.7.1
├─ @technote-space/github-action-test-helper@0.2.5
├─ @technote-space/release-github-actions-cli@1.3.0
├─ @technote-space/release-github-actions@3.0.5
├─ @types/babel__core@7.1.6
├─ @types/babel__generator@7.6.1
├─ @types/babel__template@7.0.2
├─ @types/babel__traverse@7.0.9
├─ @types/color-name@1.1.1
├─ @types/eslint-visitor-keys@1.0.0
├─ @types/istanbul-lib-coverage@2.0.1
├─ @types/istanbul-lib-report@3.0.0
├─ @types/istanbul-reports@1.1.1
├─ @types/jest@25.1.3
├─ @types/json-schema@7.0.4
├─ @types/node@13.7.7
├─ @types/parse-json@4.0.0
├─ @types/stack-utils@1.0.1
├─ @types/yargs-parser@15.0.0
├─ @typescript-eslint/eslint-plugin@2.22.0
├─ @typescript-eslint/parser@2.22.0
├─ acorn-globals@4.3.4
├─ acorn-jsx@5.2.0
├─ acorn-walk@6.2.0
├─ ajv@6.12.0
├─ any-observable@0.3.0
├─ anymatch@3.1.1
├─ argparse@1.0.10
├─ arr-flatten@1.1.0
├─ array-equal@1.0.0
├─ array-find-index@1.0.2
├─ array-ify@1.0.0
├─ arrify@1.0.1
├─ asn1@0.2.4
├─ assign-symbols@1.0.0
├─ asynckit@0.4.0
├─ atob-lite@2.0.0
├─ atob@2.1.2
├─ aws-sign2@0.7.0
├─ aws4@1.9.1
├─ babel-jest@25.1.0
├─ babel-plugin-jest-hoist@25.1.0
├─ babel-polyfill@6.26.0
├─ babel-preset-jest@25.1.0
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ bcrypt-pbkdf@1.0.2
├─ before-after-hook@2.1.0
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ browser-process-hrtime@0.1.3
├─ browser-resolve@1.11.3
├─ bs-logger@0.2.6
├─ bser@2.1.1
├─ btoa-lite@1.0.0
├─ buffer-from@1.1.1
├─ cache-base@1.0.1
├─ caller-callsite@2.0.0
├─ caller-path@2.0.0
├─ camelcase-keys@4.2.0
├─ capture-exit@2.0.0
├─ caseless@0.12.0
├─ chardet@0.7.0
├─ class-utils@0.3.6
├─ cli-cursor@2.1.0
├─ cli-truncate@0.2.1
├─ cli-width@2.2.0
├─ cliui@6.0.0
├─ code-point-at@1.1.0
├─ collection-visit@1.0.0
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ combined-stream@1.0.8
├─ commander@4.1.1
├─ compare-versions@3.6.0
├─ concat-map@0.0.1
├─ conventional-changelog-angular@1.6.6
├─ conventional-changelog-conventionalcommits@4.2.1
├─ conventional-commits-parser@3.0.8
├─ convert-source-map@1.7.0
├─ copy-descriptor@0.1.1
├─ core-js@2.6.11
├─ core-util-is@1.0.2
├─ cross-spawn@6.0.5
├─ cssom@0.4.4
├─ cssstyle@2.2.0
├─ currently-unhandled@0.4.1
├─ dargs@4.1.0
├─ dashdash@1.14.1
├─ data-urls@1.1.0
├─ date-fns@1.30.1
├─ decamelize-keys@1.1.0
├─ decode-uri-component@0.2.0
├─ dedent@0.7.0
├─ deep-is@0.1.3
├─ delayed-stream@1.0.0
├─ deprecation@2.3.1
├─ detect-newline@3.1.0
├─ diff-sequences@25.1.0
├─ doctrine@3.0.0
├─ dot-prop@3.0.0
├─ dotenv@8.2.0
├─ ecc-jsbn@0.1.2
├─ elegant-spinner@1.0.1
├─ emoji-regex@8.0.0
├─ end-of-stream@1.4.4
├─ es-abstract@1.17.4
├─ es-to-primitive@1.2.1
├─ escodegen@1.14.1
├─ eslint@6.8.0
├─ espree@6.2.0
├─ esprima@4.0.1
├─ esquery@1.1.0
├─ esrecurse@4.2.1
├─ estraverse@4.3.0
├─ expand-brackets@2.1.4
├─ extend@3.0.2
├─ external-editor@3.1.0
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fast-deep-equal@3.1.1
├─ fast-levenshtein@2.0.6
├─ figures@3.2.0
├─ file-entry-cache@5.0.1
├─ fill-range@7.0.1
├─ find-versions@3.2.0
├─ flat-cache@2.0.1
├─ flatted@2.0.1
├─ for-in@1.0.2
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ fs.realpath@1.0.0
├─ gensync@1.0.0-beta.1
├─ get-caller-file@2.0.5
├─ get-own-enumerable-property-symbols@3.0.2
├─ get-stdin@7.0.0
├─ get-stream@4.1.0
├─ get-value@2.0.6
├─ getpass@0.1.7
├─ git-raw-commits@2.0.3
├─ glob-parent@5.1.0
├─ glob@7.1.6
├─ global-dirs@0.1.1
├─ globals@12.3.0
├─ growly@1.3.0
├─ har-schema@2.0.0
├─ har-validator@5.1.3
├─ has-ansi@2.0.0
├─ has-value@1.0.0
├─ hosted-git-info@2.8.8
├─ html-encoding-sniffer@1.0.2
├─ html-escaper@2.0.0
├─ http-signature@1.2.0
├─ human-signals@1.1.1
├─ husky@4.2.3
├─ iconv-lite@0.4.24
├─ ignore@4.0.6
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ini@1.3.5
├─ inquirer@7.0.5
├─ ip-regex@2.1.0
├─ is-accessor-descriptor@1.0.0
├─ is-arrayish@0.2.1
├─ is-callable@1.1.5
├─ is-data-descriptor@1.0.0
├─ is-date-object@1.0.2
├─ is-descriptor@1.0.2
├─ is-directory@0.3.1
├─ is-extglob@2.1.1
├─ is-obj@1.0.1
├─ is-observable@1.1.0
├─ is-plain-obj@1.1.0
├─ is-plain-object@2.0.4
├─ is-regex@1.0.5
├─ is-regexp@1.0.0
├─ is-symbol@1.0.3
├─ is-text-path@1.0.1
├─ is-typedarray@1.0.0
├─ is-windows@1.0.2
├─ is-wsl@2.1.1
├─ isarray@1.0.0
├─ isstream@0.1.2
├─ istanbul-lib-source-maps@4.0.0
├─ istanbul-reports@3.0.0
├─ jest-changed-files@25.1.0
├─ jest-circus@25.1.0
├─ jest-cli@25.1.0
├─ jest-docblock@25.1.0
├─ jest-environment-jsdom@25.1.0
├─ jest-environment-node@25.1.0
├─ jest-leak-detector@25.1.0
├─ jest-pnp-resolver@1.2.1
├─ jest-resolve-dependencies@25.1.0
├─ jest-serializer@25.1.0
├─ jest-watcher@25.1.0
├─ jest@25.1.0
├─ js-tokens@4.0.0
├─ jsdom@15.2.1
├─ jsesc@2.5.2
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@2.1.1
├─ jsonparse@1.3.1
├─ JSONStream@1.3.5
├─ jsprim@1.4.1
├─ kind-of@3.2.2
├─ kleur@3.0.3
├─ leven@3.1.0
├─ levn@0.3.0
├─ lines-and-columns@1.1.6
├─ lint-staged@10.0.8
├─ listr-silent-renderer@1.1.1
├─ listr-update-renderer@0.5.0
├─ listr-verbose-renderer@0.5.0
├─ listr@0.14.3
├─ load-json-file@4.0.0
├─ locate-path@5.0.0
├─ lodash.get@4.4.2
├─ lodash.memoize@4.1.2
├─ lodash.set@4.3.2
├─ lodash.sortby@4.7.0
├─ lodash.template@4.5.0
├─ lodash.templatesettings@4.2.0
├─ lodash.uniq@4.5.0
├─ log-symbols@3.0.0
├─ log-update@2.3.0
├─ lolex@5.1.2
├─ loud-rejection@1.6.0
├─ macos-release@2.3.0
├─ make-dir@3.0.2
├─ make-error@1.3.6
├─ makeerror@1.0.11
├─ map-obj@1.0.1
├─ map-visit@1.0.0
├─ mime-db@1.43.0
├─ mime-types@2.1.26
├─ mimic-fn@2.1.0
├─ minimist-options@3.0.2
├─ mixin-deep@1.3.2
├─ mkdirp@0.5.1
├─ ms@2.1.2
├─ mute-stream@0.0.8
├─ nanomatch@1.2.13
├─ nice-try@1.0.5
├─ nock@12.0.2
├─ node-fetch@2.6.0
├─ node-int64@0.4.0
├─ node-modules-regexp@1.0.0
├─ node-notifier@6.0.0
├─ normalize-package-data@2.5.0
├─ npm-run-path@2.0.2
├─ nwsapi@2.2.0
├─ oauth-sign@0.9.0
├─ object-assign@4.1.1
├─ object-copy@0.1.0
├─ object-inspect@1.7.0
├─ object-keys@1.1.1
├─ object.assign@4.1.0
├─ object.getownpropertydescriptors@2.1.0
├─ octokit-pagination-methods@1.1.0
├─ opencollective-postinstall@2.0.2
├─ optionator@0.8.3
├─ os-tmpdir@1.0.2
├─ p-each-series@2.1.0
├─ p-finally@1.0.0
├─ p-limit@2.2.2
├─ p-locate@4.1.0
├─ p-map@2.1.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ parse5@5.1.0
├─ pascalcase@0.1.1
├─ path-exists@4.0.0
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ path-type@4.0.0
├─ performance-now@2.1.0
├─ picomatch@2.2.1
├─ pirates@4.0.1
├─ pn@1.1.0
├─ posix-character-classes@0.1.1
├─ process-nextick-args@2.0.1
├─ progress@2.0.3
├─ prompts@2.3.1
├─ propagate@2.0.1
├─ qs@6.5.2
├─ quick-lru@1.1.0
├─ react-is@16.13.0
├─ read-pkg-up@3.0.0
├─ read-pkg@3.0.0
├─ readable-stream@3.6.0
├─ redent@2.0.0
├─ regenerator-runtime@0.10.5
├─ regexpp@2.0.1
├─ remove-trailing-separator@1.1.0
├─ repeat-element@1.1.3
├─ request-promise-core@1.1.3
├─ request-promise-native@1.0.8
├─ request@2.88.2
├─ require-directory@2.1.1
├─ require-main-filename@2.0.0
├─ resolve-cwd@3.0.0
├─ resolve-global@1.0.0
├─ resolve-url@0.2.1
├─ resolve@1.15.1
├─ restore-cursor@2.0.0
├─ ret@0.1.15
├─ rimraf@3.0.2
├─ rsvp@4.8.5
├─ run-async@2.4.0
├─ rxjs@6.5.4
├─ safer-buffer@2.1.2
├─ sane@4.1.0
├─ saxes@3.1.11
├─ semver-compare@1.0.0
├─ semver-regex@2.0.0
├─ semver@6.3.0
├─ set-blocking@2.0.0
├─ set-value@2.0.1
├─ shebang-command@1.2.0
├─ shebang-regex@1.0.0
├─ shell-escape@0.2.0
├─ shellwords@0.1.1
├─ sisteransi@1.0.4
├─ slice-ansi@2.1.0
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-map-resolve@0.5.3
├─ source-map-support@0.5.16
├─ source-map-url@0.4.0
├─ source-map@0.6.1
├─ spdx-correct@3.1.0
├─ spdx-exceptions@2.2.0
├─ split-string@3.1.0
├─ sprintf-js@1.1.2
├─ sshpk@1.16.1
├─ static-extend@0.1.2
├─ stealthy-require@1.1.1
├─ string_decoder@1.3.0
├─ string-argv@0.3.1
├─ string.prototype.trimleft@2.1.1
├─ string.prototype.trimright@2.1.1
├─ stringify-object@3.3.0
├─ strip-bom@4.0.0
├─ strip-eof@1.0.0
├─ strip-final-newline@2.0.0
├─ strip-indent@2.0.0
├─ strip-json-comments@3.0.1
├─ supports-hyperlinks@2.1.0
├─ symbol-observable@1.2.0
├─ symbol-tree@3.2.4
├─ table@5.4.6
├─ terminal-link@2.1.1
├─ test-exclude@6.0.0
├─ text-extensions@1.9.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ tmp@0.0.33
├─ to-fast-properties@2.0.0
├─ to-object-path@0.3.0
├─ to-regex-range@5.0.1
├─ tough-cookie@2.5.0
├─ tr46@1.0.1
├─ trim-newlines@2.0.0
├─ trim-off-newlines@1.0.1
├─ ts-jest@25.2.1
├─ tslib@1.11.1
├─ tunnel-agent@0.6.0
├─ tunnel@0.0.6
├─ tweetnacl@0.14.5
├─ type-detect@4.0.8
├─ type-fest@0.11.0
├─ typedarray-to-buffer@3.1.5
├─ typescript@3.8.3
├─ union-value@1.0.1
├─ unset-value@1.0.0
├─ uri-js@4.2.2
├─ urix@0.1.0
├─ use@3.1.1
├─ util-deprecate@1.0.2
├─ util.promisify@1.0.1
├─ uuid@3.4.0
├─ v8-compile-cache@2.1.0
├─ v8-to-istanbul@4.1.2
├─ validate-npm-package-license@3.0.4
├─ verror@1.10.0
├─ w3c-hr-time@1.0.1
├─ w3c-xmlserializer@1.1.2
├─ walker@1.0.7
├─ whatwg-encoding@1.0.5
├─ whatwg-mimetype@2.3.0
├─ which-module@2.0.0
├─ which-pm-runs@1.0.0
├─ which@1.3.1
├─ windows-release@3.2.0
├─ word-wrap@1.2.3
├─ wrap-ansi@3.0.1
├─ write-file-atomic@3.0.3
├─ write@1.0.3
├─ ws@7.2.1
├─ xmlchars@2.2.0
├─ xtend@4.0.2
├─ y18n@4.0.0
└─ yaml@1.7.2
Done in 11.90s.
```

### stderr:

```Shell
warning @commitlint/cli > babel-polyfill > core-js@2.6.11: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
warning @commitlint/cli > babel-polyfill > babel-runtime > core-js@2.6.11: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
warning jest > @jest/core > jest-config > jest-environment-jsdom > jsdom > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
```

</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.21.1
0 vulnerabilities found - Packages audited: 1223298
Done in 1.48s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)