### PR TITLE
fix: treat `npm ci` & `npm install` as install command

### DIFF
--- a/src/utils/misc.test.ts
+++ b/src/utils/misc.test.ts
@@ -478,7 +478,7 @@ describe('getBuildCommands', () => {
     ]);
   });
 
-  it('should get build commands 10', () => {
+  it('should get build commands 12', () => {
     process.env.INPUT_PACKAGE_MANAGER     = 'yarn';
     process.env.INPUT_DELETE_NODE_MODULES = 'true';
     process.env.INPUT_BUILD_COMMAND       = 'tsc && yarn ncc build lib/main.js && rm -rf lib';
@@ -489,6 +489,16 @@ describe('getBuildCommands', () => {
       'rm -rf lib',
       'rm -rdf node_modules',
       ...clean(buildDir1),
+    ]);
+  });
+
+  it('should get build commands 13', () => {
+    process.env.INPUT_PACKAGE_MANAGER = 'npm';
+    process.env.INPUT_BUILD_COMMAND   = 'npm ci && npm run package';
+    expect(getBuildCommands(buildDir7, pushDir)).toEqual([
+      'npm ci',
+      'npm run package',
+      ...clean(buildDir7),
     ]);
   });
 });

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -98,7 +98,7 @@ export const getBuildCommands = (buildDir: string, pushDir: string): Array<Comma
   const pkgManager              = Utils.useNpm(buildDir, getInput('PACKAGE_MANAGER')) ? 'npm' : 'yarn';
   const runSubCommand           = pkgManager === 'npm' ? ' run ' : ' ';
   const runCommand              = [pkgManager, runSubCommand].join('');
-  const hasInstallCommand       = !!commands.filter(command => command.includes(`${runCommand}install`)).length;
+  const hasInstallCommand       = commands.some(command => command.includes(`${pkgManager} install`) || command.includes('npm ci'));
   const buildCommands           = detectBuildCommands(buildDir, runCommand, commands);
   const deleteNodeModules       = Utils.getBoolValue(getInput('DELETE_NODE_MODULES'));
 


### PR DESCRIPTION
## Description: 概要
`BUILD_COMMAND`に`npm install`や`npm ci`が定義されている場合に、以下のコマンドが付与されることを抑制する。
これにより、予期しないインストールプロセスが動いてしまうことを防ぐ。(ex. `--ignore-scripts`)
- `npm install`
- `npm install --production` (`DELETE_NODE_MODULES`が`true`でないとき)

close #455 

## Changes: 変更内容
- `utils/misc.ts`の`getBuildCommands`内にある`hasInstallCommand`の条件式を下記のように変更
  - Before: `BUILD_COMMAND`に定義されたコマンド内に`npm run install`または`yarn install`を含む
  - After: `BUILD_COMMAND`に定義されたコマンド内に${pkgManager} install`または`npm ci`のいずれかを含む

## Expected Impact: 影響範囲
`BUILD_COMMAND`に`npm install`や`npm ci`を定義していた場合、今まで実行されていた`npm install`コマンドが実行されなくなる。
ただ今までの動作がバグ的挙動であるため、実際に影響を受ける可能性は軽微である。

### 影響を受けるケース
```yml
- uses: technote-space/release-github-actions@v8
  with:
    BUILD_COMMAND: npm ci --ignore-scripts && npm run build
```
- 現行で実行されるコマンド
  - `npm install`
  - `npm ci --ignore-scripts`
  - `npm run build`
  - `rm -rdf node_modules`
  - `npm install --production`
- 修正後に実行されるコマンド
  - `npm ci --ignore-scripts`
  - `npm run build`

今までのビルド動作が`npm install`部分(≒`postinstall`などで実行されるnpm script)に依存していた場合に、破壊的変更となる。

## Operating Requirements: 動作要件

## Additional context: 補足
